### PR TITLE
Return original filename

### DIFF
--- a/lib/filepicker_client.rb
+++ b/lib/filepicker_client.rb
@@ -284,7 +284,7 @@ end
 
 # Filepicker File Container
 class FilepickerClientFile
-  attr_accessor :mime_type, :size, :handle, :store_key, :client
+  attr_accessor :mime_type, :size, :handle, :store_key, :filename, :client
 
   # Create an object linked to the client to interact with the file in Filepicker
   # @param blob [Hash] Information about the file from Filepicker
@@ -295,6 +295,7 @@ class FilepickerClientFile
     @size = blob['size']
     @handle = URI.parse(blob['url']).path.split('/').last.strip unless blob['url'].nil?
     @store_key = blob['key']
+    @filename = blob['filename']
 
     @client = client
 

--- a/test/test_filepicker_client.rb
+++ b/test/test_filepicker_client.rb
@@ -47,6 +47,9 @@ class TestFilepickerClient < Test::Unit::TestCase
       # store
       file = client.store(store_file, 'test')
 
+      # file attributes
+      assert_match /^test\.txt/, file.filename
+
       #file_uri
       file_uri = file.file_uri
       assert_equal "https://www.filepicker.io/api/file/#{file.handle}", file_uri.to_s


### PR DESCRIPTION
I want the original filename so I can show it in my app. I am not 100% sure if we should give it a better name like `original_filename` (that seems to be what I'm calling it and some other libraries use it IIRC). 

How do you feel about switching the tests to use real fixture files so we can assert the file size and file name better? Right now the filename ends up being a random tempfile name so I can just match the beginning. 
