### PR TITLE
Af convert

### DIFF
--- a/doc/FilepickerClient.html
+++ b/doc/FilepickerClient.html
@@ -174,6 +174,30 @@ Filepicker API</p>
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#convert_and_store-instance_method" title="#convert_and_store (instance method)">- (FilepickerClientFile) <strong>convert_and_store</strong>(handle, path = nil, options = {}) </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Store a converted version of a file under the target storage path.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#file_read_uri_and_expiry-instance_method" title="#file_read_uri_and_expiry (instance method)">- (Hash) <strong>file_read_uri_and_expiry</strong>(handle, expiry = DEFAULT_POLICY_EXPIRY) </a>
     
 
@@ -555,7 +579,189 @@ requests and signing operations</p>
 
     
       <div class="method_details first">
-  <h3 class="signature first" id="file_read_uri_and_expiry-instance_method">
+  <h3 class="signature first" id="convert_and_store-instance_method">
+  
+    - (<tt><span class='object_link'><a href="FilepickerClientFile.html" title="FilepickerClientFile (class)">FilepickerClientFile</a></span></tt>) <strong>convert_and_store</strong>(handle, path = nil, options = {}) 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Store a converted version of a file under the target storage path.</p>
+
+<p>For all available options, see Filepicker&#39;s <a
+href="https://developers.inkfilepicker.com/docs/web/#inkblob-images">Image
+Conversion API</a>.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>handle</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>Handle for the original file in Filepicker</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>path</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>Path the file should be organized under in the destination storage</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>options</span>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>{}</tt>)</em>
+      
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="FilepickerClientFile.html" title="FilepickerClientFile (class)">FilepickerClientFile</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>Object representing the uploaded file in Filepicker</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+172
+173
+174
+175
+176
+177
+178
+179
+180
+181
+182
+183
+184
+185
+186
+187
+188
+189
+190
+191
+192
+193
+194
+195
+196
+197
+198
+199
+200
+201
+202
+203
+204
+205
+206
+207
+208</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 172</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_convert_and_store'>convert_and_store</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_path'>path</span><span class='op'>=</span><span class='kw'>nil</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='comment'># Build a convert url for the file
+</span>  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span> <span class='op'>+=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/convert</span><span class='tstring_end'>&quot;</span></span>
+
+  <span class='comment'># Sign to allow store of a new file under the target path.
+</span>  <span class='comment'># The handle of the file being read is not required.
+</span>  <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span>
+    <span class='label'>expiry:</span> <span class='const'>DEFAULT_POLICY_EXPIRY</span><span class='comma'>,</span>
+    <span class='label'>path:</span> <span class='id identifier rubyid_path'>path</span><span class='comma'>,</span>
+    <span class='label'>call:</span> <span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>convert</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>store</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
+  <span class='rparen'>)</span>
+
+  <span class='comment'># Add key, signature, and policy into the query string along
+</span>  <span class='comment'># with the convert options.
+</span>  <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_merge!'>merge!</span><span class='lparen'>(</span>
+    <span class='label'>key:</span> <span class='ivar'>@api_key</span><span class='comma'>,</span>
+    <span class='label'>signature:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:signature</span><span class='rbracket'>]</span><span class='comma'>,</span>
+    <span class='label'>policy:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:encoded_policy</span><span class='rbracket'>]</span><span class='comma'>,</span>
+    <span class='label'>storeLocation:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>S3</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span>
+    <span class='label'>storePath:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:policy</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>path</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
+  <span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_query'>query</span> <span class='op'>=</span> <span class='const'>URI</span><span class='period'>.</span><span class='id identifier rubyid_encode_www_form'>encode_www_form</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
+
+  <span class='id identifier rubyid_resource'>resource</span> <span class='op'>=</span> <span class='id identifier rubyid_get_fp_resource'>get_fp_resource</span> <span class='id identifier rubyid_uri'>uri</span>
+
+  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_resource'>resource</span><span class='period'>.</span><span class='id identifier rubyid_post'>post</span><span class='lparen'>(</span><span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>  <span class='comment'># all data in query string already, empty hash is just to allow this call to be made
+</span>
+  <span class='kw'>if</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span> <span class='op'>==</span> <span class='int'>200</span>
+    <span class='id identifier rubyid_response_data'>response_data</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span>
+    <span class='id identifier rubyid_file'>file</span> <span class='op'>=</span> <span class='const'>FilepickerClientFile</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span> <span class='id identifier rubyid_response_data'>response_data</span><span class='comma'>,</span> <span class='kw'>self</span>
+
+    <span class='kw'>return</span> <span class='id identifier rubyid_file'>file</span>
+  <span class='kw'>else</span>
+    <span class='id identifier rubyid_raise'>raise</span> <span class='const'>FilepickerClientError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>failed to store (code: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span><span class='embexpr_end'>}</span><span class='tstring_content'>)</span><span class='tstring_end'>&quot;</span></span>
+  <span class='kw'>end</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="file_read_uri_and_expiry-instance_method">
   
     - (<tt>Hash</tt>) <strong>file_read_uri_and_expiry</strong>(handle, expiry = DEFAULT_POLICY_EXPIRY) 
   
@@ -828,21 +1034,21 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-187
-188
-189
-190
-191
-192
-193
-194
-195
-196
-197
-198</pre>
+233
+234
+235
+236
+237
+238
+239
+240
+241
+242
+243
+244</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 187</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 233</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_read'>read</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='symbol'>:uri</span><span class='rbracket'>]</span>
@@ -925,29 +1131,29 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-253
-254
-255
-256
-257
-258
-259
-260
-261
-262
-263
-264
-265
-266
-267
-268
-269
-270
-271
-272</pre>
+299
+300
+301
+302
+303
+304
+305
+306
+307
+308
+309
+310
+311
+312
+313
+314
+315
+316
+317
+318</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 253</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 299</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove'>remove</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:remove</span><span class='rparen'>)</span>
@@ -1211,25 +1417,25 @@ Filepicker requests</p>
       <pre class="lines">
 
 
-167
-168
-169
-170
-171
-172
-173
-174
-175
-176
-177
-178
-179
-180
-181
-182</pre>
+213
+214
+215
+216
+217
+218
+219
+220
+221
+222
+223
+224
+225
+226
+227
+228</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 167</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 213</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='symbol'>:uri</span><span class='rbracket'>]</span>
@@ -1611,29 +1817,29 @@ through Filepicker.</p>
       <pre class="lines">
 
 
-204
-205
-206
-207
-208
-209
-210
-211
-212
-213
-214
-215
-216
-217
-218
-219
-220
-221
-222
-223</pre>
+250
+251
+252
+253
+254
+255
+256
+257
+258
+259
+260
+261
+262
+263
+264
+265
+266
+267
+268
+269</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 204</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 250</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write'>write</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file'>file</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:write</span><span class='rparen'>)</span>
@@ -1741,29 +1947,29 @@ URL.</p>
       <pre class="lines">
 
 
-229
-230
-231
-232
-233
-234
-235
-236
-237
-238
-239
-240
-241
-242
-243
-244
-245
-246
-247
-248</pre>
+275
+276
+277
+278
+279
+280
+281
+282
+283
+284
+285
+286
+287
+288
+289
+290
+291
+292
+293
+294</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 229</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 275</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write_url'>write_url</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file_url'>file_url</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:writeUrl</span><span class='rparen'>)</span>
@@ -1795,7 +2001,7 @@ URL.</p>
 </div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:51 2013 by
+  Generated on Thu Nov  7 11:11:52 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/FilepickerClientError.html
+++ b/doc/FilepickerClientError.html
@@ -125,7 +125,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:51 2013 by
+  Generated on Thu Nov  7 11:11:52 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/FilepickerClientFile.html
+++ b/doc/FilepickerClientFile.html
@@ -147,6 +147,33 @@
       <li class="public ">
   <span class="summary_signature">
     
+      <a href="#filename-instance_method" title="#filename (instance method)">- (Object) <strong>filename</strong> </a>
+    
+
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Returns the value of attribute filename.</p>
+</div></span>
+  
+</li>
+
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#handle-instance_method" title="#handle (instance method)">- (Object) <strong>handle</strong> </a>
     
 
@@ -529,27 +556,29 @@ Filepicker</p>
       <pre class="lines">
 
 
-293
-294
-295
-296
-297
-298
-299
-300
-301
-302
-303
-304</pre>
+339
+340
+341
+342
+343
+344
+345
+346
+347
+348
+349
+350
+351</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 293</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 339</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_blob'>blob</span><span class='comma'>,</span> <span class='id identifier rubyid_client'>client</span><span class='rparen'>)</span>
   <span class='ivar'>@mime_type</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>type</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
   <span class='ivar'>@size</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>size</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
   <span class='ivar'>@handle</span> <span class='op'>=</span> <span class='const'>URI</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>url</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span><span class='period'>.</span><span class='id identifier rubyid_split'>split</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span><span class='period'>.</span><span class='id identifier rubyid_strip'>strip</span> <span class='kw'>unless</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>url</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
   <span class='ivar'>@store_key</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>key</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
+  <span class='ivar'>@filename</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>filename</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
 
   <span class='ivar'>@client</span> <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span>
 
@@ -595,15 +624,58 @@ Filepicker</p>
       <pre class="lines">
 
 
-287
-288
-289</pre>
+333
+334
+335</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 287</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_client'>client</span>
   <span class='ivar'>@client</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      
+      <span id="filename=-instance_method"></span>
+      <div class="method_details ">
+  <h3 class="signature " id="filename-instance_method">
+  
+    - (<tt>Object</tt>) <strong>filename</strong> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns the value of attribute filename</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+333
+334
+335</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_filename'>filename</span>
+  <span class='ivar'>@filename</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -638,12 +710,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-287
-288
-289</pre>
+333
+334
+335</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 287</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_handle'>handle</span>
   <span class='ivar'>@handle</span>
@@ -681,12 +753,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-287
-288
-289</pre>
+333
+334
+335</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 287</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mime_type'>mime_type</span>
   <span class='ivar'>@mime_type</span>
@@ -724,12 +796,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-287
-288
-289</pre>
+333
+334
+335</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 287</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_size'>size</span>
   <span class='ivar'>@size</span>
@@ -767,12 +839,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-287
-288
-289</pre>
+333
+334
+335</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 287</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_store_key'>store_key</span>
   <span class='ivar'>@store_key</span>
@@ -855,12 +927,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-315
-316
-317</pre>
+362
+363
+364</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 315</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 362</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_expiry'>expiry</span><span class='op'>=</span><span class='const'>FilepickerClient</span><span class='op'>::</span><span class='const'>DEFAULT_POLICY_EXPIRY</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_expiry'>expiry</span><span class='rparen'>)</span>
@@ -914,12 +986,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-308
-309
-310</pre>
+355
+356
+357</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 308</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 355</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_uri'>file_uri</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='ivar'>@handle</span><span class='rparen'>)</span>
@@ -973,12 +1045,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-331
-332
-333</pre>
+378
+379
+380</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 331</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 378</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_read'>read</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span> <span class='ivar'>@handle</span>
@@ -1032,12 +1104,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-351
-352
-353</pre>
+398
+399
+400</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 351</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 398</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove'>remove</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_remove'>remove</span> <span class='ivar'>@handle</span>
@@ -1091,16 +1163,16 @@ Filepicker</p>
       <pre class="lines">
 
 
-321
-322
-323
-324
-325
-326
-327</pre>
+368
+369
+370
+371
+372
+373
+374</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 321</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 368</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_updated_info'>updated_info</span> <span class='op'>=</span> <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_stat'>stat</span> <span class='ivar'>@handle</span>
@@ -1178,12 +1250,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-338
-339
-340</pre>
+385
+386
+387</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 338</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 385</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write'>write</span><span class='lparen'>(</span><span class='id identifier rubyid_file'>file</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_write'>write</span> <span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file'>file</span>
@@ -1257,12 +1329,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-345
-346
-347</pre>
+392
+393
+394</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 345</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 392</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write_url'>write_url</span><span class='lparen'>(</span><span class='id identifier rubyid_file_url'>file_url</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_write_url'>write_url</span> <span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file_url'>file_url</span>
@@ -1277,7 +1349,7 @@ Filepicker</p>
 </div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:51 2013 by
+  Generated on Thu Nov  7 11:11:52 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -111,7 +111,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:50 2013 by
+  Generated on Thu Nov  7 11:11:51 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -142,7 +142,7 @@ path and attempt to remove them when finished.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:50 2013 by
+  Generated on Thu Nov  7 11:11:51 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -142,7 +142,7 @@ path and attempt to remove them when finished.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:50 2013 by
+  Generated on Thu Nov  7 11:11:51 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/method_list.html
+++ b/doc/method_list.html
@@ -54,8 +54,8 @@
   
 
   <li class="r2 ">
-    <span class='object_link'><a href="FilepickerClientFile.html#file_read_uri_and_expiry-instance_method" title="FilepickerClientFile#file_read_uri_and_expiry (method)">#file_read_uri_and_expiry</a></span>
-    <small>FilepickerClientFile</small>
+    <span class='object_link'><a href="FilepickerClient.html#convert_and_store-instance_method" title="FilepickerClient#convert_and_store (method)">#convert_and_store</a></span>
+    <small>FilepickerClient</small>
   </li>
   
 
@@ -66,13 +66,25 @@
   
 
   <li class="r2 ">
+    <span class='object_link'><a href="FilepickerClientFile.html#file_read_uri_and_expiry-instance_method" title="FilepickerClientFile#file_read_uri_and_expiry (method)">#file_read_uri_and_expiry</a></span>
+    <small>FilepickerClientFile</small>
+  </li>
+  
+
+  <li class="r1 ">
     <span class='object_link'><a href="FilepickerClient.html#file_uri-instance_method" title="FilepickerClient#file_uri (method)">#file_uri</a></span>
     <small>FilepickerClient</small>
   </li>
   
 
-  <li class="r1 ">
+  <li class="r2 ">
     <span class='object_link'><a href="FilepickerClientFile.html#file_uri-instance_method" title="FilepickerClientFile#file_uri (method)">#file_uri</a></span>
+    <small>FilepickerClientFile</small>
+  </li>
+  
+
+  <li class="r1 ">
+    <span class='object_link'><a href="FilepickerClientFile.html#filename-instance_method" title="FilepickerClientFile#filename (method)">#filename</a></span>
     <small>FilepickerClientFile</small>
   </li>
   
@@ -84,14 +96,14 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="FilepickerClient.html#initialize-instance_method" title="FilepickerClient#initialize (method)">#initialize</a></span>
-    <small>FilepickerClient</small>
+    <span class='object_link'><a href="FilepickerClientFile.html#initialize-instance_method" title="FilepickerClientFile#initialize (method)">#initialize</a></span>
+    <small>FilepickerClientFile</small>
   </li>
   
 
   <li class="r2 ">
-    <span class='object_link'><a href="FilepickerClientFile.html#initialize-instance_method" title="FilepickerClientFile#initialize (method)">#initialize</a></span>
-    <small>FilepickerClientFile</small>
+    <span class='object_link'><a href="FilepickerClient.html#initialize-instance_method" title="FilepickerClient#initialize (method)">#initialize</a></span>
+    <small>FilepickerClient</small>
   </li>
   
 
@@ -168,14 +180,14 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="FilepickerClient.html#write-instance_method" title="FilepickerClient#write (method)">#write</a></span>
-    <small>FilepickerClient</small>
+    <span class='object_link'><a href="FilepickerClientFile.html#write-instance_method" title="FilepickerClientFile#write (method)">#write</a></span>
+    <small>FilepickerClientFile</small>
   </li>
   
 
   <li class="r2 ">
-    <span class='object_link'><a href="FilepickerClientFile.html#write-instance_method" title="FilepickerClientFile#write (method)">#write</a></span>
-    <small>FilepickerClientFile</small>
+    <span class='object_link'><a href="FilepickerClient.html#write-instance_method" title="FilepickerClient#write (method)">#write</a></span>
+    <small>FilepickerClient</small>
   </li>
   
 

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -103,7 +103,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Aug 19 09:49:50 2013 by
+  Generated on Thu Nov  7 11:11:51 2013 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/filepicker_client.gemspec
+++ b/filepicker_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "filepicker_client"
-  s.version     = "0.1.0"
+  s.version     = "0.2.0"
   s.date        = "2013-07-25"
   s.summary     = "Filepicker.io Client"
   s.description = "A simple library for interfacing with the Filepicker.io REST API"


### PR DESCRIPTION
This adds the "convert_and_store" call to the client. It is currently lacking tests, but so far it seems to be working well. Testing this is a bit difficult since it deals with image manipulation. The tests for this should probably be addressed in https://github.com/infowrap/filepicker_client/issues/5 since we'll probably need a static image file to test against.

The new call uses Filepicker's image conversion API to generate a new file and then store it at a specified path.
