### PR TITLE
Change stat to use Filepicker's metadata call instead of HEAD to allow r...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gemspec   # load filepicker_client.gemspec as a gem
 
+gem 'activesupport'
 gem 'rake'
 gem 'yard'

--- a/doc/FilepickerClient.html
+++ b/doc/FilepickerClient.html
@@ -346,7 +346,7 @@ requests and signing operations.</p>
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#stat-instance_method" title="#stat (instance method)">- (Hash) <strong>stat</strong>(handle) </a>
+      <a href="#stat-instance_method" title="#stat (instance method)">- (Hash) <strong>stat</strong>(handle, options = {}) </a>
     
 
     
@@ -552,14 +552,14 @@ requests and signing operations</p>
       <pre class="lines">
 
 
-16
 17
 18
 19
-20</pre>
+20
+21</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_api_key'>api_key</span><span class='comma'>,</span> <span class='id identifier rubyid_api_secret'>api_secret</span><span class='comma'>,</span> <span class='id identifier rubyid_filepicker_cert'>filepicker_cert</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='ivar'>@api_key</span> <span class='op'>=</span> <span class='id identifier rubyid_api_key'>api_key</span>
@@ -677,8 +677,6 @@ Conversion API</a>.</p>
       <pre class="lines">
 
 
-172
-173
 174
 175
 176
@@ -713,12 +711,18 @@ Conversion API</a>.</p>
 205
 206
 207
-208</pre>
+208
+209
+210
+211
+212</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 172</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 174</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_convert_and_store'>convert_and_store</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_path'>path</span><span class='op'>=</span><span class='kw'>nil</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_convert_and_store'>convert_and_store</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_path'>path</span><span class='op'>=</span><span class='kw'>nil</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span><span class='op'>=</span><span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
+
   <span class='comment'># Build a convert url for the file
 </span>  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span> <span class='op'>+=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/convert</span><span class='tstring_end'>&quot;</span></span>
@@ -733,7 +737,7 @@ Conversion API</a>.</p>
 
   <span class='comment'># Add key, signature, and policy into the query string along
 </span>  <span class='comment'># with the convert options.
-</span>  <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_merge!'>merge!</span><span class='lparen'>(</span>
+</span>  <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span>
     <span class='label'>key:</span> <span class='ivar'>@api_key</span><span class='comma'>,</span>
     <span class='label'>signature:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:signature</span><span class='rbracket'>]</span><span class='comma'>,</span>
     <span class='label'>policy:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:encoded_policy</span><span class='rbracket'>]</span><span class='comma'>,</span>
@@ -846,8 +850,6 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-87
-88
 89
 90
 91
@@ -863,10 +865,12 @@ the URI (:expiry)</p>
 101
 102
 103
-104</pre>
+104
+105
+106</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 87</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 89</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_expiry'>expiry</span><span class='op'>=</span><span class='const'>DEFAULT_POLICY_EXPIRY</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span>
@@ -881,10 +885,10 @@ the URI (:expiry)</p>
     <span class='label'>policy:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:encoded_policy</span><span class='rbracket'>]</span>
   <span class='rparen'>)</span>
 
-  <span class='kw'>return</span> <span class='lbrace'>{</span>
+  <span class='kw'>return</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span>
     <span class='label'>uri:</span> <span class='id identifier rubyid_uri'>uri</span><span class='comma'>,</span>
     <span class='label'>expiry:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:policy</span><span class='rbracket'>]</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>expiry</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span>
-  <span class='rbrace'>}</span>
+  <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -955,12 +959,12 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-78
-79
-80</pre>
+80
+81
+82</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 78</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 80</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='const'>URI</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='const'>FP_FILE_PATH</span> <span class='op'>+</span> <span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
@@ -1034,21 +1038,21 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-233
-234
-235
-236
-237
-238
-239
-240
-241
-242
-243
-244</pre>
+273
+274
+275
+276
+277
+278
+279
+280
+281
+282
+283
+284</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 233</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 273</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_read'>read</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='symbol'>:uri</span><span class='rbracket'>]</span>
@@ -1131,29 +1135,29 @@ the URI (:expiry)</p>
       <pre class="lines">
 
 
-299
-300
-301
-302
-303
-304
-305
-306
-307
-308
-309
-310
-311
-312
-313
-314
-315
-316
-317
-318</pre>
+339
+340
+341
+342
+343
+344
+345
+346
+347
+348
+349
+350
+351
+352
+353
+354
+355
+356
+357
+358</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 299</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 339</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove'>remove</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:remove</span><span class='rparen'>)</span>
@@ -1268,7 +1272,6 @@ Filepicker requests</p>
       <pre class="lines">
 
 
-36
 37
 38
 39
@@ -1305,12 +1308,15 @@ Filepicker requests</p>
 70
 71
 72
-73</pre>
+73
+74
+75</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 36</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 37</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='op'>=</span><span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:expiration_start</span><span class='rbracket'>]</span> <span class='op'>||=</span> <span class='const'>Time</span><span class='period'>.</span><span class='id identifier rubyid_now'>now</span>
   <span class='id identifier rubyid_options'>options</span><span class='lbracket'>[</span><span class='symbol'>:expiry</span><span class='rbracket'>]</span> <span class='op'>||=</span> <span class='const'>DEFAULT_POLICY_EXPIRY</span>
 
@@ -1342,11 +1348,11 @@ Filepicker requests</p>
   <span class='comment'># Sign policy using our API secret
 </span>  <span class='id identifier rubyid_signature'>signature</span> <span class='op'>=</span> <span class='const'>OpenSSL</span><span class='op'>::</span><span class='const'>HMAC</span><span class='period'>.</span><span class='id identifier rubyid_hexdigest'>hexdigest</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>sha256</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='ivar'>@api_secret</span><span class='comma'>,</span> <span class='id identifier rubyid_encoded_policy'>encoded_policy</span><span class='rparen'>)</span>
 
-  <span class='kw'>return</span> <span class='lbrace'>{</span>
-    <span class='label'>policy:</span> <span class='id identifier rubyid_policy'>policy</span><span class='comma'>,</span>
+  <span class='kw'>return</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span>
+    <span class='label'>policy:</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_policy'>policy</span><span class='rparen'>)</span><span class='comma'>,</span>
     <span class='label'>encoded_policy:</span> <span class='id identifier rubyid_encoded_policy'>encoded_policy</span><span class='comma'>,</span>
     <span class='label'>signature:</span> <span class='id identifier rubyid_signature'>signature</span>
-  <span class='rbrace'>}</span>
+  <span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1356,7 +1362,7 @@ Filepicker requests</p>
       <div class="method_details ">
   <h3 class="signature " id="stat-instance_method">
   
-    - (<tt>Hash</tt>) <strong>stat</strong>(handle) 
+    - (<tt>Hash</tt>) <strong>stat</strong>(handle, options = {}) 
   
 
   
@@ -1366,6 +1372,21 @@ Filepicker requests</p>
   <div class="discussion">
     
 <p>Get basic information about a file.</p>
+
+<p>Set any of the following keys to true in the options to enable certain
+fields in the data retrieved:
+* mimetype
+* uploaded
+* container
+*
+writeable
+* filename
+* location
+* key
+* path
+* size
+* width
+* height</p>
 
 
   </div>
@@ -1386,6 +1407,24 @@ Filepicker requests</p>
         &mdash;
         <div class='inline'>
 <p>Handle for the file in Filepicker</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>options</span>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>{}</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>Options for generating the desired signature</p>
 </div>
       
     </li>
@@ -1417,38 +1456,80 @@ Filepicker requests</p>
       <pre class="lines">
 
 
-213
-214
-215
-216
-217
-218
-219
-220
-221
-222
-223
-224
-225
-226
-227
-228</pre>
+232
+233
+234
+235
+236
+237
+238
+239
+240
+241
+242
+243
+244
+245
+246
+247
+248
+249
+250
+251
+252
+253
+254
+255
+256
+257
+258
+259
+260
+261
+262
+263
+264
+265
+266
+267
+268</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 213</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 232</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='symbol'>:uri</span><span class='rbracket'>]</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_options'>options</span><span class='op'>=</span><span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
+
+  <span class='comment'># Build a metadata url for the file
+</span>  <span class='comment'># (this call returns more information than a HEAD request against the resource)
+</span>  <span class='id identifier rubyid_uri'>uri</span> <span class='op'>=</span> <span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span> <span class='op'>+=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/metadata</span><span class='tstring_end'>&quot;</span></span>
+
+  <span class='comment'># Sign to allow store of a new file under the target path.
+</span>  <span class='comment'># The handle of the file being read is not required.
+</span>  <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span>
+    <span class='label'>expiry:</span> <span class='const'>DEFAULT_POLICY_EXPIRY</span><span class='comma'>,</span>
+    <span class='label'>call:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>stat</span><span class='tstring_end'>&#39;</span></span>
+  <span class='rparen'>)</span>
+
+  <span class='comment'># Add key, signature, and policy into the query string along
+</span>  <span class='comment'># with the metadata options.
+</span>  <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='id identifier rubyid_options'>options</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span>
+    <span class='label'>key:</span> <span class='ivar'>@api_key</span><span class='comma'>,</span>
+    <span class='label'>signature:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:signature</span><span class='rbracket'>]</span><span class='comma'>,</span>
+    <span class='label'>policy:</span> <span class='id identifier rubyid_signage'>signage</span><span class='lbracket'>[</span><span class='symbol'>:encoded_policy</span><span class='rbracket'>]</span>
+  <span class='rparen'>)</span>
+  <span class='id identifier rubyid_uri'>uri</span><span class='period'>.</span><span class='id identifier rubyid_query'>query</span> <span class='op'>=</span> <span class='const'>URI</span><span class='period'>.</span><span class='id identifier rubyid_encode_www_form'>encode_www_form</span><span class='lparen'>(</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
+
   <span class='id identifier rubyid_resource'>resource</span> <span class='op'>=</span> <span class='id identifier rubyid_get_fp_resource'>get_fp_resource</span> <span class='id identifier rubyid_uri'>uri</span>
 
-  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_resource'>resource</span><span class='period'>.</span><span class='id identifier rubyid_head'>head</span>
+  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_resource'>resource</span><span class='period'>.</span><span class='id identifier rubyid_get'>get</span>
 
   <span class='kw'>if</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span> <span class='op'>==</span> <span class='int'>200</span>
-    <span class='kw'>return</span> <span class='lbrace'>{</span>
-      <span class='label'>name:</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_headers'>headers</span><span class='lbracket'>[</span><span class='symbol'>:x_file_name</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='comma'>,</span>
-      <span class='label'>size:</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_headers'>headers</span><span class='lbracket'>[</span><span class='symbol'>:content_length</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
-      <span class='label'>mime_type:</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_headers'>headers</span><span class='lbracket'>[</span><span class='symbol'>:content_type</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
-    <span class='rbrace'>}</span>
+    <span class='id identifier rubyid_response_data'>response_data</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_stats'>stats</span> <span class='op'>=</span> <span class='id identifier rubyid_convert_hash'>convert_hash</span><span class='lparen'>(</span><span class='id identifier rubyid_response_data'>response_data</span><span class='rparen'>)</span>
+
+    <span class='kw'>return</span> <span class='id identifier rubyid_stats'>stats</span>
   <span class='kw'>else</span>
     <span class='id identifier rubyid_raise'>raise</span> <span class='const'>FilepickerClientError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>failed to get file stats (code: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span><span class='embexpr_end'>}</span><span class='tstring_content'>)</span><span class='tstring_end'>&quot;</span></span>
   <span class='kw'>end</span>
@@ -1540,8 +1621,6 @@ Filepicker requests</p>
       <pre class="lines">
 
 
-110
-111
 112
 113
 114
@@ -1563,10 +1642,12 @@ Filepicker requests</p>
 130
 131
 132
-133</pre>
+133
+134
+135</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 110</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 112</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_store'>store</span><span class='lparen'>(</span><span class='id identifier rubyid_file'>file</span><span class='comma'>,</span> <span class='id identifier rubyid_path'>path</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>path:</span> <span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:store</span><span class='rparen'>)</span>
@@ -1585,7 +1666,7 @@ Filepicker requests</p>
 
   <span class='kw'>if</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span> <span class='op'>==</span> <span class='int'>200</span>
     <span class='id identifier rubyid_response_data'>response_data</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span>
-    <span class='id identifier rubyid_file'>file</span> <span class='op'>=</span> <span class='const'>FilepickerClientFile</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span> <span class='id identifier rubyid_response_data'>response_data</span><span class='comma'>,</span> <span class='kw'>self</span>
+    <span class='id identifier rubyid_file'>file</span> <span class='op'>=</span> <span class='const'>FilepickerClientFile</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_response_data'>response_data</span><span class='comma'>,</span> <span class='kw'>self</span><span class='rparen'>)</span>
 
     <span class='kw'>return</span> <span class='id identifier rubyid_file'>file</span>
   <span class='kw'>else</span>
@@ -1680,8 +1761,6 @@ through Filepicker.</p>
       <pre class="lines">
 
 
-139
-140
 141
 142
 143
@@ -1703,10 +1782,12 @@ through Filepicker.</p>
 159
 160
 161
-162</pre>
+162
+163
+164</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 139</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 141</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_store_url'>store_url</span><span class='lparen'>(</span><span class='id identifier rubyid_file_url'>file_url</span><span class='comma'>,</span> <span class='id identifier rubyid_path'>path</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>path:</span> <span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:store</span><span class='rparen'>)</span>
@@ -1817,29 +1898,29 @@ through Filepicker.</p>
       <pre class="lines">
 
 
-250
-251
-252
-253
-254
-255
-256
-257
-258
-259
-260
-261
-262
-263
-264
-265
-266
-267
-268
-269</pre>
+290
+291
+292
+293
+294
+295
+296
+297
+298
+299
+300
+301
+302
+303
+304
+305
+306
+307
+308
+309</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 250</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 290</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write'>write</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file'>file</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:write</span><span class='rparen'>)</span>
@@ -1947,29 +2028,29 @@ URL.</p>
       <pre class="lines">
 
 
-275
-276
-277
-278
-279
-280
-281
-282
-283
-284
-285
-286
-287
-288
-289
-290
-291
-292
-293
-294</pre>
+315
+316
+317
+318
+319
+320
+321
+322
+323
+324
+325
+326
+327
+328
+329
+330
+331
+332
+333
+334</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 275</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 315</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write_url'>write_url</span><span class='lparen'>(</span><span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file_url'>file_url</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_signage'>signage</span> <span class='op'>=</span> <span class='id identifier rubyid_sign'>sign</span><span class='lparen'>(</span><span class='label'>handle:</span> <span class='id identifier rubyid_handle'>handle</span><span class='comma'>,</span> <span class='label'>call:</span> <span class='symbol'>:writeUrl</span><span class='rparen'>)</span>
@@ -2001,7 +2082,7 @@ URL.</p>
 </div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:52 2013 by
+  Generated on Fri Jan  3 10:53:20 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/FilepickerClientError.html
+++ b/doc/FilepickerClientError.html
@@ -125,7 +125,7 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:52 2013 by
+  Generated on Fri Jan  3 10:53:21 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/FilepickerClientFile.html
+++ b/doc/FilepickerClientFile.html
@@ -201,7 +201,7 @@
       <li class="public ">
   <span class="summary_signature">
     
-      <a href="#mime_type-instance_method" title="#mime_type (instance method)">- (Object) <strong>mime_type</strong> </a>
+      <a href="#mimetype-instance_method" title="#mimetype (instance method)">- (Object) <strong>mimetype</strong> </a>
     
 
     
@@ -219,7 +219,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Returns the value of attribute mime_type.</p>
+<p>Returns the value of attribute mimetype.</p>
 </div></span>
   
 </li>
@@ -556,25 +556,25 @@ Filepicker</p>
       <pre class="lines">
 
 
-339
-340
-341
-342
-343
-344
-345
-346
-347
-348
-349
-350
-351</pre>
+383
+384
+385
+386
+387
+388
+389
+390
+391
+392
+393
+394
+395</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 339</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 383</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_blob'>blob</span><span class='comma'>,</span> <span class='id identifier rubyid_client'>client</span><span class='rparen'>)</span>
-  <span class='ivar'>@mime_type</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>type</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
+  <span class='ivar'>@mimetype</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>type</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
   <span class='ivar'>@size</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>size</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
   <span class='ivar'>@handle</span> <span class='op'>=</span> <span class='const'>URI</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>url</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span><span class='period'>.</span><span class='id identifier rubyid_split'>split</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span><span class='period'>.</span><span class='id identifier rubyid_strip'>strip</span> <span class='kw'>unless</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>url</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
   <span class='ivar'>@store_key</span> <span class='op'>=</span> <span class='id identifier rubyid_blob'>blob</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>key</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span>
@@ -624,12 +624,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_client'>client</span>
   <span class='ivar'>@client</span>
@@ -667,12 +667,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_filename'>filename</span>
   <span class='ivar'>@filename</span>
@@ -710,12 +710,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_handle'>handle</span>
   <span class='ivar'>@handle</span>
@@ -726,11 +726,11 @@ Filepicker</p>
 </div>
     
       
-      <span id="mime_type=-instance_method"></span>
+      <span id="mimetype=-instance_method"></span>
       <div class="method_details ">
-  <h3 class="signature " id="mime_type-instance_method">
+  <h3 class="signature " id="mimetype-instance_method">
   
-    - (<tt>Object</tt>) <strong>mime_type</strong> 
+    - (<tt>Object</tt>) <strong>mimetype</strong> 
   
 
   
@@ -739,7 +739,7 @@ Filepicker</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the value of attribute mime_type</p>
+<p>Returns the value of attribute mimetype</p>
 
 
   </div>
@@ -753,15 +753,15 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_mime_type'>mime_type</span>
-  <span class='ivar'>@mime_type</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_mimetype'>mimetype</span>
+  <span class='ivar'>@mimetype</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -796,12 +796,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_size'>size</span>
   <span class='ivar'>@size</span>
@@ -839,12 +839,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-333
-334
-335</pre>
+377
+378
+379</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 377</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_store_key'>store_key</span>
   <span class='ivar'>@store_key</span>
@@ -927,12 +927,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-362
-363
-364</pre>
+406
+407
+408</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 362</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 406</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='id identifier rubyid_expiry'>expiry</span><span class='op'>=</span><span class='const'>FilepickerClient</span><span class='op'>::</span><span class='const'>DEFAULT_POLICY_EXPIRY</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_file_read_uri_and_expiry'>file_read_uri_and_expiry</span><span class='lparen'>(</span><span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_expiry'>expiry</span><span class='rparen'>)</span>
@@ -986,12 +986,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-355
-356
-357</pre>
+399
+400
+401</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 355</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 399</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_file_uri'>file_uri</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_file_uri'>file_uri</span><span class='lparen'>(</span><span class='ivar'>@handle</span><span class='rparen'>)</span>
@@ -1045,12 +1045,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-378
-379
-380</pre>
+422
+423
+424</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 378</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 422</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_read'>read</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_read'>read</span> <span class='ivar'>@handle</span>
@@ -1104,12 +1104,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-398
-399
-400</pre>
+442
+443
+444</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 398</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 442</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove'>remove</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_remove'>remove</span> <span class='ivar'>@handle</span>
@@ -1163,20 +1163,20 @@ Filepicker</p>
       <pre class="lines">
 
 
-368
-369
-370
-371
-372
-373
-374</pre>
+412
+413
+414
+415
+416
+417
+418</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 368</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 412</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_updated_info'>updated_info</span> <span class='op'>=</span> <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_stat'>stat</span> <span class='ivar'>@handle</span>
-  <span class='ivar'>@mime_type</span> <span class='op'>=</span> <span class='id identifier rubyid_updated_info'>updated_info</span><span class='lbracket'>[</span><span class='symbol'>:mime_type</span><span class='rbracket'>]</span>
+  <span class='ivar'>@mimetype</span> <span class='op'>=</span> <span class='id identifier rubyid_updated_info'>updated_info</span><span class='lbracket'>[</span><span class='symbol'>:mimetype</span><span class='rbracket'>]</span>
   <span class='ivar'>@size</span> <span class='op'>=</span> <span class='id identifier rubyid_updated_info'>updated_info</span><span class='lbracket'>[</span><span class='symbol'>:size</span><span class='rbracket'>]</span>
 
   <span class='kw'>return</span> <span class='id identifier rubyid_updated_info'>updated_info</span>
@@ -1250,12 +1250,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-385
-386
-387</pre>
+429
+430
+431</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 385</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 429</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write'>write</span><span class='lparen'>(</span><span class='id identifier rubyid_file'>file</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_write'>write</span> <span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file'>file</span>
@@ -1329,12 +1329,12 @@ Filepicker</p>
       <pre class="lines">
 
 
-392
-393
-394</pre>
+436
+437
+438</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 392</span>
+      <pre class="code"><span class="info file"># File 'lib/filepicker_client.rb', line 436</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_write_url'>write_url</span><span class='lparen'>(</span><span class='id identifier rubyid_file_url'>file_url</span><span class='rparen'>)</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_write_url'>write_url</span> <span class='ivar'>@handle</span><span class='comma'>,</span> <span class='id identifier rubyid_file_url'>file_url</span>
@@ -1349,7 +1349,7 @@ Filepicker</p>
 </div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:52 2013 by
+  Generated on Fri Jan  3 10:53:21 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -111,7 +111,7 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:51 2013 by
+  Generated on Fri Jan  3 10:53:19 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -142,7 +142,7 @@ path and attempt to remove them when finished.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:51 2013 by
+  Generated on Fri Jan  3 10:53:20 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -142,7 +142,7 @@ path and attempt to remove them when finished.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:51 2013 by
+  Generated on Fri Jan  3 10:53:19 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/doc/method_list.html
+++ b/doc/method_list.html
@@ -108,7 +108,7 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="FilepickerClientFile.html#mime_type-instance_method" title="FilepickerClientFile#mime_type (method)">#mime_type</a></span>
+    <span class='object_link'><a href="FilepickerClientFile.html#mimetype-instance_method" title="FilepickerClientFile#mimetype (method)">#mimetype</a></span>
     <small>FilepickerClientFile</small>
   </li>
   

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -103,7 +103,7 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Nov  7 11:11:51 2013 by
+  Generated on Fri Jan  3 10:53:20 2014 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7 (ruby-2.0.0).
 </div>

--- a/lib/filepicker_client.rb
+++ b/lib/filepicker_client.rb
@@ -1,6 +1,7 @@
 require 'rest-client'
 require 'json'
 require 'base64'
+require 'active_support/hash_with_indifferent_access'
 
 # Client interface for Filepicker's REST API
 class FilepickerClient
@@ -34,6 +35,7 @@ class FilepickerClient
   # @param options [Hash] Options for generating the desired signature
   # @return [Hash] The policy generated with the encoded policy and signature for use in Filepicker requests
   def sign(options={})
+    options = convert_hash(options)
     options[:expiration_start] ||= Time.now
     options[:expiry] ||= DEFAULT_POLICY_EXPIRY
 
@@ -65,11 +67,11 @@ class FilepickerClient
     # Sign policy using our API secret
     signature = OpenSSL::HMAC.hexdigest('sha256', @api_secret, encoded_policy)
 
-    return {
-      policy: policy,
+    return convert_hash(
+      policy: convert_hash(policy),
       encoded_policy: encoded_policy,
       signature: signature
-    }
+    )
   end
 
   # Get Filepicker URI for the file with the given handle.
@@ -97,10 +99,10 @@ class FilepickerClient
       policy: signage[:encoded_policy]
     )
 
-    return {
+    return convert_hash(
       uri: uri,
       expiry: signage[:policy]['expiry'].to_i
-    }
+    )
   end
 
   # Store the given file at the given storage path through Filepicker.
@@ -124,7 +126,7 @@ class FilepickerClient
 
     if response.code == 200
       response_data = JSON.parse response.body
-      file = FilepickerClientFile.new response_data, self
+      file = FilepickerClientFile.new(response_data, self)
 
       return file
     else
@@ -169,7 +171,9 @@ class FilepickerClient
   # @param path [String] Path the file should be organized under in the destination storage
   # @param options [Hash]
   # @return [FilepickerClientFile] Object representing the uploaded file in Filepicker
-  def convert_and_store(handle, path=nil, options = {})
+  def convert_and_store(handle, path=nil, options={})
+    options = convert_hash(options)
+
     # Build a convert url for the file
     uri = file_uri(handle)
     uri.path += "/convert"
@@ -184,7 +188,7 @@ class FilepickerClient
 
     # Add key, signature, and policy into the query string along
     # with the convert options.
-    options.merge!(
+    options = options.merge(
       key: @api_key,
       signature: signage[:signature],
       policy: signage[:encoded_policy],
@@ -208,20 +212,56 @@ class FilepickerClient
   end
 
   # Get basic information about a file.
+  #
+  # Set any of the following keys to true in the options to enable certain fields in the data retrieved:
+  # * mimetype
+  # * uploaded
+  # * container
+  # * writeable
+  # * filename
+  # * location
+  # * key
+  # * path
+  # * size
+  # * width
+  # * height
+  #
   # @param handle [String] Handle for the file in Filepicker
+  # @param options [Hash] Options for generating the desired signature
   # @return [Hash] Name, size, and MIME type of the file
-  def stat(handle)
-    uri = file_read_uri_and_expiry(handle)[:uri]
+  def stat(handle, options={})
+    options = convert_hash(options)
+
+    # Build a metadata url for the file
+    # (this call returns more information than a HEAD request against the resource)
+    uri = file_uri(handle)
+    uri.path += "/metadata"
+
+    # Sign to allow store of a new file under the target path.
+    # The handle of the file being read is not required.
+    signage = sign(
+      expiry: DEFAULT_POLICY_EXPIRY,
+      call: 'stat'
+    )
+
+    # Add key, signature, and policy into the query string along
+    # with the metadata options.
+    options = options.merge(
+      key: @api_key,
+      signature: signage[:signature],
+      policy: signage[:encoded_policy]
+    )
+    uri.query = URI.encode_www_form(options)
+
     resource = get_fp_resource uri
 
-    response = resource.head
+    response = resource.get
 
     if response.code == 200
-      return {
-        name: response.headers[:x_file_name].to_s,
-        size: response.headers[:content_length].to_i,
-        mime_type: response.headers[:content_type].to_s
-      }
+      response_data = JSON.parse(response.body)
+      stats = convert_hash(response_data)
+
+      return stats
     else
       raise FilepickerClientError, "failed to get file stats (code: #{response.code})"
     end
@@ -326,18 +366,22 @@ class FilepickerClient
       ssl_client_cert: @filepicker_cert
     )
   end
+
+  def convert_hash(hash)
+    HashWithIndifferentAccess.new(hash)
+  end
 end
 
 # Filepicker File Container
 class FilepickerClientFile
-  attr_accessor :mime_type, :size, :handle, :store_key, :filename, :client
+  attr_accessor :mimetype, :size, :handle, :store_key, :filename, :client
 
   # Create an object linked to the client to interact with the file in Filepicker
   # @param blob [Hash] Information about the file from Filepicker
   # @param client [FilepickerClient] Client through which actions on this file should be taken
   # @return [FilepickerClientFile]
   def initialize(blob, client)
-    @mime_type = blob['type']
+    @mimetype = blob['type']
     @size = blob['size']
     @handle = URI.parse(blob['url']).path.split('/').last.strip unless blob['url'].nil?
     @store_key = blob['key']
@@ -367,7 +411,7 @@ class FilepickerClientFile
   # @return [Hash] Name, size, and MIME type of the file
   def stat
     updated_info = @client.stat @handle
-    @mime_type = updated_info[:mime_type]
+    @mimetype = updated_info[:mimetype]
     @size = updated_info[:size]
 
     return updated_info

--- a/test/test_filepicker_client.rb
+++ b/test/test_filepicker_client.rb
@@ -57,7 +57,7 @@ class TestFilepickerClient < Test::Unit::TestCase
       # stat
       stats = file.stat
       assert_equal content.length, stats[:size]
-      assert_equal 'text/plain; charset=utf-8', stats[:mime_type]
+      assert_equal 'text/plain', stats[:mimetype]
 
       # read
       downloaded_content = file.read


### PR DESCRIPTION
...etrieval of more information

The original 'stat' call used a HEAD request against a file's URL to retrieve some basic information about the file. Filepicker supports a GET request to a file's "/metadata" path to retrieve the same information in addition to some useful additional fields, such as width and height for image files.

Breaking Changes:
- "mime_type" is now named "mimetype" everywhere it is used to match Filepicker's "metadata" output.
