### PR TITLE
Fix store_url when path is not specified.

### DIFF
--- a/lib/filepicker_client.rb
+++ b/lib/filepicker_client.rb
@@ -142,12 +142,13 @@ class FilepickerClient
     signage = sign(path: path, call: :store)
 
     uri = URI.parse(FP_API_PATH)
-    uri.query = URI.encode_www_form(
+    query_params = {
       key: @api_key,
       signature: signage[:signature],
-      policy: signage[:encoded_policy],
-      path: signage[:policy]['path']
-    )
+      policy: signage[:encoded_policy]
+    }
+    query_params[:path] = signage[:policy]['path'] if path
+    uri.query = URI.encode_www_form(query_params)
 
     resource = get_fp_resource uri
 


### PR DESCRIPTION
Previously, "&path=" was being added to the query string, which resulted in the Filepicker API returning an "Internal Server Error".
