### PR TITLE
Avoid adding path related query string params unless a path is given

### DIFF
--- a/lib/filepicker_client.rb
+++ b/lib/filepicker_client.rb
@@ -113,13 +113,13 @@ class FilepickerClient
     signage = sign(path: path, call: :store)
 
     uri = URI.parse(FP_API_PATH)
-    uri.query = URI.encode_www_form(
+    query_params = {
       key: @api_key,
       signature: signage[:signature],
-      policy: signage[:encoded_policy],
-      path: signage[:policy]['path']
-    )
-
+      policy: signage[:encoded_policy]
+    }
+    query_params[:path] = signage[:policy]['path'] if path
+    uri.query = URI.encode_www_form(query_params)
     resource = get_fp_resource uri
 
     response = resource.post fileUpload: file
@@ -193,9 +193,9 @@ class FilepickerClient
       key: @api_key,
       signature: signage[:signature],
       policy: signage[:encoded_policy],
-      storeLocation: 'S3',
-      storePath: signage[:policy]['path']
+      storeLocation: 'S3'
     )
+    options[:storePath] = signage[:policy]['path'] if path
     uri.query = URI.encode_www_form(options)
 
     resource = get_fp_resource uri


### PR DESCRIPTION
This fixes a couple other cases similar to what was fixed in another PR: https://github.com/infowrap/filepicker_client/pull/9

If a path is not given for a store operation, it will not be added as a query string parameter to the calls store and convert_and_store make.
