### PR TITLE
Fix content type for store_url call.

### DIFF
--- a/lib/filepicker_client.rb
+++ b/lib/filepicker_client.rb
@@ -151,8 +151,7 @@ class FilepickerClient
     uri.query = URI.encode_www_form(query_params)
 
     resource = get_fp_resource uri
-
-    response = resource.post url: file_url.to_s
+    response = resource.post("url=#{CGI::escape(file_url)}", content_type: 'text/plain')
 
     if response.code == 200
       response_data = JSON.parse response.body


### PR DESCRIPTION
For some reason (I have an email in to Filepicker to find out why),
the Filepicker API does not work with a content-type of
application/x-www-url-encoded-form. RestClient forces this
content-type when a hash is provided as a payload. This commit changes
the payload and specifies a content type of text/plain.
